### PR TITLE
Property dep cross-injection to use pre-registered providers

### DIFF
--- a/ObjectMap.Tests/BasicTests.cs
+++ b/ObjectMap.Tests/BasicTests.cs
@@ -31,10 +31,8 @@ namespace ObjectMap.Tests
         {
             ObjectMap.Register<IMock, Mock>();
             ObjectMap.Register<IMock2, Mock2>();
-
-            ObjectMap.Register<IDependency, Dependency>().InjectAllPropertiesofType();
-            ObjectMap.InjectAllPropertiesofType<IDependency>();
-
+            ObjectMap.Register<IDependency, Dependency>();
+            
             var result = ObjectMap.Get<IMock2>();
 
             Assert.IsInstanceOfType(result, typeof(Mock2));

--- a/ObjectMap.Tests/ComplexTests.cs
+++ b/ObjectMap.Tests/ComplexTests.cs
@@ -10,14 +10,13 @@ namespace ObjectMap.Tests
         {
             ObjectMap.Register<IMock, Mock>();
             ObjectMap.Register<IMock2, Mock2>();
-            ObjectMap.InjectAllPropertiesofType<IDependency>();
 
             var result = ObjectMap.Get<IMock2>();
             Assert.IsInstanceOfType(result, typeof(Mock2));
             Assert.IsNull(result.Dependency);
 
             ObjectMap.Register<IDependency, Dependency>();
-            result.EnsureDependenciesInjected();
+            result.TryInjectDependencies();
             
             Assert.IsNotNull(result.Dependency);
         }

--- a/ObjectMap/ObjectMapExtensions.cs
+++ b/ObjectMap/ObjectMapExtensions.cs
@@ -4,13 +4,7 @@ namespace ObjectMap
 {
     public static class ObjectMapExtensions
     {
-        public static Type InjectAllPropertiesofType(this Type injectableType)
-        {
-            ObjectMap.Instance.InjectablesRegistry.Add(injectableType);
-            return injectableType;
-        }
-
-        public static void EnsureDependenciesInjected(this object @object)
+        public static void TryInjectDependencies(this object @object)
         {
             ObjectMap.TryInjectDependencies(@object);
         }

--- a/ObjectMap/ObjectProviders.cs
+++ b/ObjectMap/ObjectProviders.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.ObjectModel;
+
+namespace ObjectMap
+{
+    public class ObjectProviders : KeyedCollection<Type, ObjectProvider>
+    {
+        protected override Type GetKeyForItem(ObjectProvider item)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Removed separate registry for inject-able properties. Now uses provider registry. Other
minor refactoring.
